### PR TITLE
Fix potential crash on `didEndDisplayingCell`

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		6754152D27C14944004C805F /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6754152A27C14944004C805F /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6754152E27C14944004C805F /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6754152B27C14944004C805F /* EssentialFeediOS.framework */; };
 		6754152F27C14944004C805F /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6754152B27C14944004C805F /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6754B4CE27C9E7BF00721E60 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6754B4CD27C9E7BF00721E60 /* UIView+TestHelpers.swift */; };
 		675B972227C3DFEF002E8C59 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675B972127C3DFEF002E8C59 /* FeedLoaderCacheDecoratorTests.swift */; };
 		675B972427C3E8E7002E8C59 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675B972327C3E8E7002E8C59 /* FeedLoaderStub.swift */; };
 		675B972627C3EB50002E8C59 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675B972527C3EB50002E8C59 /* XCTestCase+FeedLoader.swift */; };
@@ -112,6 +113,7 @@
 		6754150C27C13D9C004C805F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6754152A27C14944004C805F /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6754152B27C14944004C805F /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6754B4CD27C9E7BF00721E60 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		675B972127C3DFEF002E8C59 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		675B972327C3E8E7002E8C59 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		675B972527C3EB50002E8C59 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				675B972D27C42062002E8C59 /* FeedImageDataLoaderSpy.swift */,
 				6752322227C8E2E700237B4F /* HTTPClientStub.swift */,
 				6752322427C8E3D300237B4F /* InMemoryFeedStore.swift */,
+				6754B4CD27C9E7BF00721E60 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				6752321C27C89F6F00237B4F /* FeedUIIntegrationTests+Localization.swift in Sources */,
 				675B972627C3EB50002E8C59 /* XCTestCase+FeedLoader.swift in Sources */,
 				675B973027C4229E002E8C59 /* XCTestCase+FeedImageDataLoader.swift in Sources */,
+				6754B4CE27C9E7BF00721E60 /* UIView+TestHelpers.swift in Sources */,
 				675231E627C8971B00237B4F /* SceneDelegateTests.swift in Sources */,
 				67E7073127C253BD00664151 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				6752321727C89F6F00237B4F /* FeedViewController+TestHelpers.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -66,8 +66,22 @@ final class FeedUIIntegrationTests: XCTestCase {
 
         sut.simulateUserInitiatedFeedReload()
         loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
-        XCTAssertEqual(sut.numberOfRenderedFeedImageViews(), 4)
         assertThat(sut, isRendering: [image0, image1, image2, image3])
+    }
+    
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
     }
     
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -12,6 +12,9 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -12,9 +12,7 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
-        
+        sut.view.enforceLayoutCycle()
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }
@@ -22,6 +20,8 @@ extension FeedUIIntegrationTests {
         feed.enumerated().forEach { index, image in
             assertThat(sut, hasViewConfiguredFor: image, at: index, file: file, line: line)
         }
+        
+        executeRunLoopToCleanUpReference()
     }
     
     func assertThat(_ sut: FeedViewController, hasViewConfiguredFor image:FeedImage, at index: Int, file: StaticString = #file, line: UInt = #line) {
@@ -39,4 +39,7 @@ extension FeedUIIntegrationTests {
         XCTAssertEqual(cell.descriptionText, image.description, "Expected decription text to be \(String(describing: image.description)) for image view at index \(index)", file: file, line: line)
     }
     
+    private func executeRunLoopToCleanUpReference() {
+        RunLoop.current.run(until: Date())
+    }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Hitesh on 26/02/22.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+    }
+}

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -15,6 +15,8 @@ public protocol FeedViewControllerDelegate {
 final public class FeedViewController : UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
     @IBOutlet private(set) public var errorView: ErrorView?
     
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -46,6 +48,7 @@ final public class FeedViewController : UITableViewController, UITableViewDataSo
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
 
@@ -72,10 +75,13 @@ final public class FeedViewController : UITableViewController, UITableViewDataSo
     }
     
     private func cellController(forRowAt indexPath:IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls didEndDisplayingCell for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.